### PR TITLE
Allow to have multiple configurations for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Or install it yourself as:
 
 ## Configuration
 
-By default NineOneOne loggs notifications and emegencies to STDOUT. You can override default settings with:
+By default NineOneOne logs notifications and emergencies to STDOUT. You can override default settings with:
 
 ```ruby
 NineOneOne.configure do |config|
@@ -50,6 +50,18 @@ NineOneOne.configure do |config|
     # Defaults to Logger.new(STDOUT)
     config.logger = Logger.new('incidents.log') 
 end
+
+# optional custom configurations
+
+NineOneOne.configure(:my_custom_configuration) do |config|
+    config.send_pagers = false
+
+    config.slack_enabled = true
+    config.slack_webhook_url = 'https://hooks.slack.com/services/XXX/YYY/ZZZ'
+
+    config.slack_username = 'NineOneOne'
+    config.slack_channel = '#my-notifications'
+end
 ```
 
 ## Usage
@@ -60,6 +72,10 @@ NineOneOne.notify('Something happened!')
 
 # Send pager or log emergency using logger depending on the `send_pagers` config parameter
 NineOneOne.emergency('INCIDENT_KEY', 'Emergency message!', { optional_hash: 'with details' })
+
+# same for custom configurations
+NineOneOne.use(:my_custom_configuration).notify('Something happened!')
+NineOneOne.use(:my_custom_configuration).emergency('INCIDENT_KEY', 'Emergency message!', { optional_hash: 'with details' })
 ```
 
 ## Development

--- a/lib/nine_one_one.rb
+++ b/lib/nine_one_one.rb
@@ -34,4 +34,12 @@ module NineOneOne
   def self.notify(message)
     use(:default).notify(message)
   end
+
+  def self.notification_service
+    use(:default).notification_service
+  end
+
+  def self.emergency_service
+    use(:default).emergency_service
+  end
 end

--- a/lib/nine_one_one.rb
+++ b/lib/nine_one_one.rb
@@ -2,47 +2,36 @@ require_relative './nine_one_one/errors'
 require_relative './nine_one_one/http'
 require_relative './nine_one_one/version'
 require_relative './nine_one_one/configuration'
+require_relative './nine_one_one/notifier'
 require_relative './nine_one_one/log_service'
 require_relative './nine_one_one/slack_service'
 require_relative './nine_one_one/pager_duty_service'
 
 module NineOneOne
-  def self.emergency_service
-    if config.send_pagers
-      PagerDutyService.new(config.pager_duty_integration_key)
-    else
-      LogService.new(config.logger)
-    end
-  end
-
-  def self.notification_service
-    if config.slack_enabled
-      SlackService.new(config.slack_webhook_url, username: config.slack_username,
-                                                 channel: config.slack_channel)
-    else
-      LogService.new(config.logger)
-    end
-  end
-
-  def self.configure
+  def self.configure(type = :default)
     config = Configuration.new
 
     yield config
 
     config.validate
 
-    @config = config
+    configs[type] = config
   end
 
-  def self.config
-    @config ||= Configuration.new
+  def self.use(type = :default)
+    config = configs.fetch(type) { raise NotConfiguredError, "Configuration type=#{type} is not configured." }
+    Notifier.new(config)
+  end
+
+  def self.configs
+    @configs ||= {}
   end
 
   def self.emergency(incident_key, description, details_hash = nil)
-    emergency_service.trigger_event(incident_key, description, details_hash)
+    use(:default).emergency(incident_key, description, details_hash)
   end
 
   def self.notify(message)
-    notification_service.notify(message)
+    use(:default).notify(message)
   end
 end

--- a/lib/nine_one_one/errors.rb
+++ b/lib/nine_one_one/errors.rb
@@ -1,6 +1,7 @@
 module NineOneOne
   class Error < RuntimeError; end
 
+  class NotConfiguredError < Error; end
   class ConfigurationError < Error; end
   class IncidentReportingError < Error; end
   class NotificationError < Error; end

--- a/lib/nine_one_one/notifier.rb
+++ b/lib/nine_one_one/notifier.rb
@@ -1,0 +1,36 @@
+module NineOneOne
+  class Notifier
+    def initialize(config)
+      @config = config
+    end
+
+    def emergency(incident_key, description, details_hash = nil)
+      emergency_service.trigger_event(incident_key, description, details_hash)
+    end
+
+    def notify(message)
+      notification_service.notify(message)
+    end
+
+    def emergency_service
+      if config.send_pagers
+        PagerDutyService.new(config.pager_duty_integration_key)
+      else
+        LogService.new(config.logger)
+      end
+    end
+
+    def notification_service
+      if config.slack_enabled
+        SlackService.new(config.slack_webhook_url, username: config.slack_username,
+                                                   channel: config.slack_channel)
+      else
+        LogService.new(config.logger)
+      end
+    end
+
+    private
+
+    attr_reader :config
+  end
+end

--- a/lib/nine_one_one/version.rb
+++ b/lib/nine_one_one/version.rb
@@ -1,3 +1,3 @@
 module NineOneOne
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.3.0'.freeze
 end

--- a/spec/nine_one_one/notifier_spec.rb
+++ b/spec/nine_one_one/notifier_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe NineOneOne::Notifier do
+  subject(:notifier) { described_class.new(config) }
+  let(:config) { NineOneOne::Configuration.new }
+
+  describe '.emergency_service' do
+    context 'when send_pagers is true' do
+      let(:config) do
+        NineOneOne::Configuration.new.tap do |config|
+          config.send_pagers = true
+          config.pager_duty_integration_key = 'pager-key-123'
+        end
+      end
+
+      it 'returns PagerDutyService' do
+        expect(notifier.emergency_service).to be_a NineOneOne::PagerDutyService
+      end
+    end
+
+    context 'when send_pagers is false' do
+      let(:send_pagers) { false }
+      let(:pager_key) { nil }
+      let(:logger) { double('Logger', info: 'info', error: 'error') }
+
+      it 'returns LogService' do
+        expect(notifier.emergency_service).to be_a NineOneOne::LogService
+      end
+    end
+  end
+
+  describe '.notification_service' do
+    let(:logger) { double('Logger', error: 'error!', info: 'info!') }
+    let(:slack_webhook_url) { 'url' }
+
+    let(:config) do
+      NineOneOne::Configuration.new.tap do |config|
+        config.slack_enabled = slack_enabled
+        config.slack_webhook_url = slack_webhook_url
+        config.logger = logger
+      end
+    end
+
+    context 'when slack is not enabled' do
+      let(:slack_enabled) { false }
+
+      it 'returns logging service' do
+        expect(notifier.notification_service).to be_a(NineOneOne::LogService)
+      end
+    end
+
+    context 'when slack is enabled' do
+      let(:slack_enabled) { true }
+
+      it 'returns slack service' do
+        expect(notifier.notification_service).to be_a(NineOneOne::SlackService)
+      end
+    end
+  end
+end

--- a/spec/nine_one_one/notifier_spec.rb
+++ b/spec/nine_one_one/notifier_spec.rb
@@ -5,6 +5,8 @@ describe NineOneOne::Notifier do
   let(:config) { NineOneOne::Configuration.new }
 
   describe '.emergency_service' do
+    subject { notifier.emergency_service }
+
     context 'when send_pagers is true' do
       let(:config) do
         NineOneOne::Configuration.new.tap do |config|
@@ -13,9 +15,7 @@ describe NineOneOne::Notifier do
         end
       end
 
-      it 'returns PagerDutyService' do
-        expect(notifier.emergency_service).to be_a NineOneOne::PagerDutyService
-      end
+      it { is_expected.to be_a NineOneOne::PagerDutyService }
     end
 
     context 'when send_pagers is false' do
@@ -23,13 +23,13 @@ describe NineOneOne::Notifier do
       let(:pager_key) { nil }
       let(:logger) { double('Logger', info: 'info', error: 'error') }
 
-      it 'returns LogService' do
-        expect(notifier.emergency_service).to be_a NineOneOne::LogService
-      end
+      it { is_expected.to be_a NineOneOne::LogService }
     end
   end
 
   describe '.notification_service' do
+    subject { notifier.notification_service }
+
     let(:logger) { double('Logger', error: 'error!', info: 'info!') }
     let(:slack_webhook_url) { 'url' }
 
@@ -43,18 +43,12 @@ describe NineOneOne::Notifier do
 
     context 'when slack is not enabled' do
       let(:slack_enabled) { false }
-
-      it 'returns logging service' do
-        expect(notifier.notification_service).to be_a(NineOneOne::LogService)
-      end
+      it { is_expected.to be_a NineOneOne::LogService }
     end
 
     context 'when slack is enabled' do
       let(:slack_enabled) { true }
-
-      it 'returns slack service' do
-        expect(notifier.notification_service).to be_a(NineOneOne::SlackService)
-      end
+      it { is_expected.to be_a NineOneOne::SlackService }
     end
   end
 end

--- a/spec/nine_one_one_spec.rb
+++ b/spec/nine_one_one_spec.rb
@@ -183,4 +183,24 @@ describe NineOneOne do
       NineOneOne.notify(message)
     end
   end
+
+  describe '.notification_service' do
+    it 'returns default notification service' do
+      notifier = instance_double(NineOneOne::Notifier)
+      allow(NineOneOne).to receive(:use).with(:default).and_return(notifier)
+      expect(notifier).to receive(:notification_service)
+
+      NineOneOne.notification_service
+    end
+  end
+
+  describe '.emergency_service' do
+    it 'returns default emergency service' do
+      notifier = instance_double(NineOneOne::Notifier)
+      allow(NineOneOne).to receive(:use).with(:default).and_return(notifier)
+      expect(notifier).to receive(:emergency_service)
+
+      NineOneOne.emergency_service
+    end
+  end
 end

--- a/spec/nine_one_one_spec.rb
+++ b/spec/nine_one_one_spec.rb
@@ -99,8 +99,8 @@ describe NineOneOne do
       end
     end
 
-    context 'multi config' do
-      it 'allows to have separate configs for different purposes' do
+    context 'with multi config' do
+      before do
         NineOneOne.configure(:urgent) do |config|
           config.slack_enabled = false
         end
@@ -110,9 +110,11 @@ describe NineOneOne do
           config.slack_channel = 'channel'
           config.slack_enabled = true
         end
+      end
 
+      it 'has separate settings for each configuration' do
         expect(NineOneOne.configs[:default].slack_enabled).to eq(false)
-        expect(NineOneOne.configs[:default].slack_enabled).to eq(false)
+        expect(NineOneOne.configs[:urgent].slack_enabled).to eq(false)
         expect(NineOneOne.configs[:non_urgent].slack_enabled).to eq(true)
       end
 
@@ -123,7 +125,7 @@ describe NineOneOne do
   end
 
   describe '.use' do
-    context 'default config' do
+    context 'with default config' do
       it 'returns preconfigured notifier' do
         NineOneOne.configure do |config|
           config.send_pagers = true
@@ -159,48 +161,48 @@ describe NineOneOne do
   end
 
   describe '.emergency' do
-    let(:notifier) { instance_double(NineOneOne::Notifier) }
+    let(:notifier) { spy(NineOneOne::Notifier) }
     let(:incident_key) { 'ERROR_KEY' }
     let(:message) { 'danger' }
     let(:details_hash) { { why: 'I dont know' } }
 
     it 'delegates sending to notifier' do
       allow(NineOneOne).to receive(:use).and_return(notifier)
-      expect(notifier).to receive(:emergency).with(incident_key, message, details_hash)
-
       NineOneOne.emergency(incident_key, message, details_hash)
+      expect(notifier).to have_received(:emergency).with(incident_key, message, details_hash)
     end
   end
 
   describe '.notify' do
-    let(:notifier) { instance_double(NineOneOne::Notifier) }
+    let(:notifier) { spy(NineOneOne::Notifier) }
     let(:message) { 'alert' }
 
     it 'delegates notification to notifier' do
       allow(NineOneOne).to receive(:use).with(:default).and_return(notifier)
-      expect(notifier).to receive(:notify).with(message)
-
       NineOneOne.notify(message)
+      expect(notifier).to have_received(:notify).with(message)
     end
   end
 
   describe '.notification_service' do
-    it 'returns default notification service' do
-      notifier = instance_double(NineOneOne::Notifier)
-      allow(NineOneOne).to receive(:use).with(:default).and_return(notifier)
-      expect(notifier).to receive(:notification_service)
+    let(:notifier) { spy(NineOneOne::Notifier) }
 
+    it 'returns default notification service' do
+      allow(NineOneOne).to receive(:use).with(:default).and_return(notifier)
       NineOneOne.notification_service
+
+      expect(notifier).to have_received(:notification_service)
     end
   end
 
   describe '.emergency_service' do
-    it 'returns default emergency service' do
-      notifier = instance_double(NineOneOne::Notifier)
-      allow(NineOneOne).to receive(:use).with(:default).and_return(notifier)
-      expect(notifier).to receive(:emergency_service)
+    let(:notifier) { spy(NineOneOne::Notifier) }
 
+    it 'returns default emergency service' do
+      allow(NineOneOne).to receive(:use).with(:default).and_return(notifier)
       NineOneOne.emergency_service
+
+      expect(notifier).to have_received(:emergency_service)
     end
   end
 end

--- a/spec/nine_one_one_spec.rb
+++ b/spec/nine_one_one_spec.rb
@@ -5,79 +5,6 @@ describe NineOneOne do
     expect(NineOneOne::VERSION).not_to be nil
   end
 
-  before { NineOneOne.instance_variable_set(:@config, nil) }
-
-  describe 'default config' do
-    it 'is valid' do
-      config = NineOneOne.config
-
-      expect { config.validate }.not_to raise_error
-    end
-  end
-
-  describe '.emergency_service' do
-    context 'when send_pagers is true' do
-      let(:send_pagers) { true }
-      let(:pager_key) { 'pager-key-123' }
-
-      it 'returns PagerDutyService' do
-        NineOneOne.configure do |config|
-          config.send_pagers = send_pagers
-          config.pager_duty_integration_key = pager_key
-        end
-
-        expect(NineOneOne.emergency_service).to be_a NineOneOne::PagerDutyService
-      end
-    end
-
-    context 'when send_pagers is false' do
-      let(:send_pagers) { false }
-      let(:pager_key) { nil }
-      let(:logger) { double('Logger', info: 'info', error: 'error') }
-
-      it 'returns LogService' do
-        NineOneOne.configure do |config|
-          config.send_pagers = send_pagers
-          config.pager_duty_integration_key = pager_key
-          config.logger = logger
-        end
-
-        expect(NineOneOne.emergency_service).to be_a NineOneOne::LogService
-      end
-    end
-  end
-
-  describe '.notification_service' do
-    let(:logger) { double('Logger', error: 'error!', info: 'info!') }
-    let(:slack_webhook_url) { 'url' }
-
-    subject { described_class.notification_service }
-
-    before do
-      NineOneOne.configure do |config|
-        config.slack_enabled = slack_enabled
-        config.slack_webhook_url = slack_webhook_url
-        config.logger = logger
-      end
-    end
-
-    context 'when slack is not enabled' do
-      let(:slack_enabled) { false }
-
-      it 'returns logging service' do
-        expect(subject).to be_a(NineOneOne::LogService)
-      end
-    end
-
-    context 'when slack is enabled' do
-      let(:slack_enabled) { true }
-
-      it 'returns slack service' do
-        expect(subject).to be_a(NineOneOne::SlackService)
-      end
-    end
-  end
-
   describe 'configuration' do
     it 'accepts "send_pagers" param' do
       NineOneOne.configure do |config|
@@ -85,7 +12,7 @@ describe NineOneOne do
         config.pager_duty_integration_key = 'key-123'
       end
 
-      expect(NineOneOne.config.send_pagers).to eq true
+      expect(NineOneOne.configs[:default].send_pagers).to eq true
     end
 
     it 'raises error when send_pagers is nil' do
@@ -139,7 +66,7 @@ describe NineOneOne do
           config.pager_duty_integration_key = 'pager-key-123'
         end
 
-        expect(NineOneOne.config.pager_duty_integration_key).to eq 'pager-key-123'
+        expect(NineOneOne.configs[:default].pager_duty_integration_key).to eq 'pager-key-123'
       end
 
       it 'raises error if "pager_duty_integration_key" is null but send_pagers is true' do
@@ -171,31 +98,87 @@ describe NineOneOne do
         end.to raise_error(NineOneOne::ConfigurationError)
       end
     end
+
+    context 'multi config' do
+      it 'allows to have separate configs for different purposes' do
+        NineOneOne.configure(:urgent) do |config|
+          config.slack_enabled = false
+        end
+
+        NineOneOne.configure(:non_urgent) do |config|
+          config.slack_webhook_url = 'webhook'
+          config.slack_channel = 'channel'
+          config.slack_enabled = true
+        end
+
+        expect(NineOneOne.configs[:default].slack_enabled).to eq(false)
+        expect(NineOneOne.configs[:default].slack_enabled).to eq(false)
+        expect(NineOneOne.configs[:non_urgent].slack_enabled).to eq(true)
+      end
+
+      it 'raises error when non-existent configuration is requested' do
+        expect { NineOneOne.use(:foo) }.to raise_error(NineOneOne::NotConfiguredError)
+      end
+    end
+  end
+
+  describe '.use' do
+    context 'default config' do
+      it 'returns preconfigured notifier' do
+        NineOneOne.configure do |config|
+          config.send_pagers = true
+          config.pager_duty_integration_key = 'integration key'
+          config.slack_enabled = true
+          config.slack_channel = 'channel'
+          config.slack_webhook_url = 'http://example.com'
+        end
+
+        notifier = NineOneOne.use(:default)
+
+        expect(notifier.notification_service).to be_an_instance_of(NineOneOne::SlackService)
+        expect(notifier.emergency_service).to be_an_instance_of(NineOneOne::PagerDutyService)
+      end
+    end
+
+    context 'custom config' do
+      it 'returns preconfigured notifier' do
+        NineOneOne.configure(:my_custom_config) do |config|
+          config.send_pagers = true
+          config.pager_duty_integration_key = 'integration key'
+          config.slack_enabled = true
+          config.slack_channel = 'channel'
+          config.slack_webhook_url = 'http://example.com'
+        end
+
+        notifier = NineOneOne.use(:my_custom_config)
+
+        expect(notifier.notification_service).to be_an_instance_of(NineOneOne::SlackService)
+        expect(notifier.emergency_service).to be_an_instance_of(NineOneOne::PagerDutyService)
+      end
+    end
   end
 
   describe '.emergency' do
-    let(:emergency_service) { instance_double(NineOneOne::PagerDutyService) }
+    let(:notifier) { instance_double(NineOneOne::Notifier) }
     let(:incident_key) { 'ERROR_KEY' }
     let(:message) { 'danger' }
     let(:details_hash) { { why: 'I dont know' } }
 
-    it 'delegates sending to emergency service' do
-      allow(NineOneOne).to receive(:emergency_service).and_return(emergency_service)
-
-      expect(emergency_service).to receive(:trigger_event).with(incident_key, message, details_hash)
+    it 'delegates sending to notifier' do
+      allow(NineOneOne).to receive(:use).and_return(notifier)
+      expect(notifier).to receive(:emergency).with(incident_key, message, details_hash)
 
       NineOneOne.emergency(incident_key, message, details_hash)
     end
   end
 
   describe '.notify' do
-    let(:notification_service) { instance_double(NineOneOne::SlackService) }
+    let(:notifier) { instance_double(NineOneOne::Notifier) }
     let(:message) { 'alert' }
 
-    it 'delegates notification to notification service' do
-      allow(NineOneOne).to receive(:notification_service).and_return(notification_service)
-
-      expect(notification_service).to receive(:notify).with(message)
+    it 'delegates notification to notifier' do
+      allow(NineOneOne).to receive(:use).with(:default).and_return(notifier)
+      expect(notifier).to receive(:notify).with(message)
 
       NineOneOne.notify(message)
     end


### PR DESCRIPTION
This enables more control over where notifications go.
Eg:
 - for new features maybe notification should go only to developers
 - for big projects, maybe not all pagers are equal

It should be 100% backwards compatible with previous version of NineOneOne (apart from removal of one method `NineOneOne.config` which supposed to be not used anyway).