### PR TITLE
Add dedup_key to pager duty

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
     - bin/**/*
     - db/**/*
     - vendor/**/*
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.2
 
 Style/MultilineOperationIndentation:
   EnforcedStyle: indented

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 cache: bundler
 before_install: gem update --remote bundler
 rvm:
-  - 2.1.5
   - 2.2.5
   - 2.3.1
 script: "bundle exec rake spec"

--- a/README.md
+++ b/README.md
@@ -77,11 +77,14 @@ NineOneOne.notify('Something happened!')
 NineOneOne.notify({attachments: [{title: 'Something happened!', text: 'More info'}]})
 
 # Send pager or log emergency using logger depending on the `send_pagers` config parameter
-NineOneOne.emergency('Emergency message!', 'Error source info', { optional_hash: 'with details' })
+NineOneOne.emergency('Emergency message!', 'Error source info', details_hash: { optional_hash: 'with details' })
+
+# Send pager that if resend will be grouped into one incident
+NineOneOne.emergency('Emergency message!', 'Error source info', dedup_key: 'Kinda unique key') 
 
 # same for custom configurations
 NineOneOne.use(:my_custom_configuration).notify('Something happened!')
-NineOneOne.use(:my_custom_configuration).emergency('INCIDENT_KEY', 'Emergency message!', { optional_hash: 'with details' })
+NineOneOne.use(:my_custom_configuration).emergency('Emergency message!', 'Error source info', details_hash: { optional_hash: 'with details' })
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -77,14 +77,14 @@ NineOneOne.notify('Something happened!')
 NineOneOne.notify({attachments: [{title: 'Something happened!', text: 'More info'}]})
 
 # Send pager or log emergency using logger depending on the `send_pagers` config parameter
-NineOneOne.emergency('Emergency message!', 'Error source info', details_hash: { optional_hash: 'with details' })
+NineOneOne.emergency('Emergency message!', details_hash: { optional_hash: 'with details' })
 
 # Send multiple pagers that will be grouped into one incident
-NineOneOne.emergency('Emergency message!', 'Error source info', dedup_key: 'Kinda unique key') 
+NineOneOne.emergency('Emergency message!', dedup_key: 'Kinda unique key') 
 
 # same for custom configurations
 NineOneOne.use(:my_custom_configuration).notify('Something happened!')
-NineOneOne.use(:my_custom_configuration).emergency('Emergency message!', 'Error source info', details_hash: { optional_hash: 'with details' })
+NineOneOne.use(:my_custom_configuration).emergency('Emergency message!', details_hash: { optional_hash: 'with details' })
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 # Changelog
 
+2.0.0 Change the interface to have default parameters. Introduce dedup_key. It's backwards incompatible again.
+
 1.0.0 Migrate to Pager Duty Events API V2 (backwards incompatible!) and add support for slack hash message.
 
 0.3.0 Allow to have multiple configurations for notifications 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ NineOneOne.notify({attachments: [{title: 'Something happened!', text: 'More info
 # Send pager or log emergency using logger depending on the `send_pagers` config parameter
 NineOneOne.emergency('Emergency message!', 'Error source info', details_hash: { optional_hash: 'with details' })
 
-# Send pager that if resend will be grouped into one incident
+# Send multiple pagers that will be grouped into one incident
 NineOneOne.emergency('Emergency message!', 'Error source info', dedup_key: 'Kinda unique key') 
 
 # same for custom configurations

--- a/lib/nine_one_one.rb
+++ b/lib/nine_one_one.rb
@@ -30,7 +30,7 @@ module NineOneOne
   def self.emergency(description, source, details_hash: nil, severity: PagerDutyService::HIGH_URGENCY_ERROR,
                      dedup_key: nil)
     use(:default).emergency(description, source, details_hash: details_hash, severity: severity,
-                                                 dedup_key: dedup_key)
+                                 dedup_key: dedup_key)
   end
 
   def self.notify(message)

--- a/lib/nine_one_one.rb
+++ b/lib/nine_one_one.rb
@@ -27,8 +27,10 @@ module NineOneOne
     @configs ||= {}
   end
 
-  def self.emergency(description, source, details_hash = nil, severity = PagerDutyService::HIGH_URGENCY_ERROR)
-    use(:default).emergency(description, source, details_hash, severity)
+  def self.emergency(description, source, details_hash: nil, severity: PagerDutyService::HIGH_URGENCY_ERROR,
+                     dedup_key: nil)
+    use(:default).emergency(description, source, details_hash: details_hash, severity: severity,
+                                                 dedup_key: dedup_key)
   end
 
   def self.notify(message)

--- a/lib/nine_one_one.rb
+++ b/lib/nine_one_one.rb
@@ -27,10 +27,11 @@ module NineOneOne
     @configs ||= {}
   end
 
-  def self.emergency(description, source, details_hash: nil, severity: PagerDutyService::HIGH_URGENCY_ERROR,
-                     dedup_key: nil)
-    use(:default).emergency(description, source, details_hash: details_hash, severity: severity,
-                                 dedup_key: dedup_key)
+  def self.emergency(description, source: Socket.gethostname, dedup_key: nil,
+                     severity: PagerDutyService::HIGH_URGENCY_ERROR, details_hash: nil)
+    use(:default).emergency(description, source: source, dedup_key: dedup_key, severity: severity,
+                                 details_hash: details_hash)
+
   end
 
   def self.notify(message)

--- a/lib/nine_one_one/notifier.rb
+++ b/lib/nine_one_one/notifier.rb
@@ -4,9 +4,10 @@ module NineOneOne
       @config = config
     end
 
-    def emergency(description, source, details_hash:, severity:, dedup_key:)
-      emergency_service.trigger_event(description, source, details_hash: details_hash, severity: severity,
-                                                           dedup_key: dedup_key)
+    def emergency(description, source, dedup_key: nil, severity: PagerDutyService::HIGH_URGENCY_ERROR,
+                  details_hash: nil)
+      emergency_service.trigger_event(description, source, dedup_key: dedup_key, severity: severity,
+                                      details_hash: details_hash)
     end
 
     def notify(message)
@@ -24,7 +25,7 @@ module NineOneOne
     def notification_service
       if config.slack_enabled
         SlackService.new(config.slack_webhook_url, username: config.slack_username,
-                                                   channel: config.slack_channel)
+                         channel: config.slack_channel)
       else
         LogService.new(config.logger)
       end

--- a/lib/nine_one_one/notifier.rb
+++ b/lib/nine_one_one/notifier.rb
@@ -4,8 +4,9 @@ module NineOneOne
       @config = config
     end
 
-    def emergency(description, source, details_hash, severity)
-      emergency_service.trigger_event(description, source, details_hash, severity)
+    def emergency(description, source, details_hash:, severity:, dedup_key:)
+      emergency_service.trigger_event(description, source, details_hash: details_hash, severity: severity,
+                                                           dedup_key: dedup_key)
     end
 
     def notify(message)

--- a/lib/nine_one_one/notifier.rb
+++ b/lib/nine_one_one/notifier.rb
@@ -4,9 +4,9 @@ module NineOneOne
       @config = config
     end
 
-    def emergency(description, source, dedup_key: nil, severity: PagerDutyService::HIGH_URGENCY_ERROR,
-                  details_hash: nil)
-      emergency_service.trigger_event(description, source, dedup_key: dedup_key, severity: severity,
+    def emergency(description, source: Socket.gethostname, dedup_key: nil,
+                  severity: PagerDutyService::HIGH_URGENCY_ERROR, details_hash: nil)
+      emergency_service.trigger_event(description, source: source, dedup_key: dedup_key, severity: severity,
                                       details_hash: details_hash)
     end
 

--- a/lib/nine_one_one/pager_duty_service.rb
+++ b/lib/nine_one_one/pager_duty_service.rb
@@ -12,7 +12,8 @@ module NineOneOne
       @http = Http.new(BASE_HOST)
     end
 
-    def trigger_event(description, source, dedup_key: nil, severity: HIGH_URGENCY_ERROR, details_hash: nil)
+    def trigger_event(description, source: Socket.gethostname, dedup_key: nil, severity: HIGH_URGENCY_ERROR,
+                      details_hash: nil)
       response = nil
 
       retry_on(THROTTLE_HTTP_STATUS, THROTTLE_RETRIES) do

--- a/lib/nine_one_one/pager_duty_service.rb
+++ b/lib/nine_one_one/pager_duty_service.rb
@@ -11,11 +11,12 @@ module NineOneOne
       @http = Http.new(BASE_HOST)
     end
 
-    def trigger_event(description, source, details_hash, severity)
+    def trigger_event(description, source, details_hash: nil, severity: PagerDutyService::HIGH_URGENCY_ERROR,
+                      dedup_key: nil)
       response = nil
 
       retry_on(THROTTLE_HTTP_STATUS, THROTTLE_RETRIES) do
-        body = request_body(description, severity, source, details_hash)
+        body = request_body(description, severity, source, details_hash, dedup_key)
         response = make_request(body)
         response.code.to_i
       end
@@ -46,10 +47,11 @@ module NineOneOne
       http.post(EVENTS_API_V2_ENDPOINT, body, headers)
     end
 
-    def request_body(description, severity, source, details_hash)
+    def request_body(description, severity, source, details_hash, dedup_key)
       body = {
         routing_key: api_integration_key,
         event_action: 'trigger',
+        dedup_key: dedup_key,
         payload: {
           summary: description,
           severity: severity,

--- a/lib/nine_one_one/pager_duty_service.rb
+++ b/lib/nine_one_one/pager_duty_service.rb
@@ -37,12 +37,12 @@ module NineOneOne
 
       while yield == value && retry_number <= retries_number
         retry_number += 1
-        sleep 2 ** retry_number
+        sleep 2**retry_number
       end
     end
 
     def make_request(body)
-      headers = { 'Content-Type' => 'application/json' }
+      headers = {'Content-Type' => 'application/json'}
 
       http.post(EVENTS_API_V2_ENDPOINT, body, headers)
     end

--- a/lib/nine_one_one/slack_service.rb
+++ b/lib/nine_one_one/slack_service.rb
@@ -3,15 +3,15 @@ module NineOneOne
     def initialize(webhook_url, opts = {})
       uri = URI(webhook_url)
 
-      @channel  = opts[:channel]
-      @http     = opts[:http] || Http.new(uri.host, uri.scheme)
-      @path     = uri.path
+      @channel = opts[:channel]
+      @http = opts[:http] || Http.new(uri.host, uri.scheme)
+      @path = uri.path
       @username = opts[:username]
     end
 
     def notify(message)
       body = request_body(message)
-      headers = { 'Content-Type' => 'application/json' }
+      headers = {'Content-Type' => 'application/json'}
       http.post(path, body, headers)
     end
 
@@ -20,8 +20,8 @@ module NineOneOne
     attr_reader :channel, :http, :path, :username
 
     def request_body(message)
-      body = message.is_a?(Hash) ? message : { text: message }
-      body[:channel]  = channel  unless channel.nil?
+      body = message.is_a?(Hash) ? message : {text: message}
+      body[:channel] = channel unless channel.nil?
       body[:username] = username unless username.nil?
 
       body.to_json

--- a/lib/nine_one_one/version.rb
+++ b/lib/nine_one_one/version.rb
@@ -1,3 +1,3 @@
 module NineOneOne
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.0.3'.freeze
 end

--- a/lib/nine_one_one/version.rb
+++ b/lib/nine_one_one/version.rb
@@ -1,3 +1,3 @@
 module NineOneOne
-  VERSION = '1.0.0'.freeze
+  VERSION = '2.0.0'.freeze
 end

--- a/nine_one_one.gemspec
+++ b/nine_one_one.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.1'
-  spec.post_install_message = 'From Ver 1.0.0 emergency method call is not backwards compatible!'
+  spec.required_ruby_version = '>= 2.2'
+  spec.post_install_message = 'From Ver 2.0.0 emergency method call is not backwards compatible!'
 
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0'

--- a/spec/fixtures/vcr/pager_duty_trigger_event_failure.yml
+++ b/spec/fixtures/vcr/pager_duty_trigger_event_failure.yml
@@ -6,7 +6,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"routing_key":"PAGER_DUTY_API_INTEGRATION_TOKEN","event_action":"trigger","payload":{"summary":"Incident
-        description","severity":"error","source":null,"custom_details":{}}}'
+        description","severity":"error","custom_details":{}}}'
     headers:
       Content-Type:
       - application/json
@@ -24,7 +24,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 22 Feb 2018 13:13:03 GMT
+      - Tue, 24 Jul 2018 12:40:59 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -36,5 +36,5 @@ http_interactions:
       string: '{"status":"invalid event","message":"Event object is invalid","errors":["''payload.source''
         is missing or blank"]}'
     http_version: 
-  recorded_at: Thu, 22 Feb 2018 13:13:03 GMT
+  recorded_at: Tue, 24 Jul 2018 12:40:59 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/pager_duty_trigger_event_success.yml
+++ b/spec/fixtures/vcr/pager_duty_trigger_event_success.yml
@@ -6,7 +6,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"routing_key":"PAGER_DUTY_API_INTEGRATION_TOKEN","event_action":"trigger","payload":{"summary":"Incident
-        description","severity":"error","source":"source info","custom_details":{"backtrace":"log"}}}'
+        description","source":"source info","severity":"error","custom_details":{"backtrace":"log"}}}'
     headers:
       Content-Type:
       - application/json
@@ -24,7 +24,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 22 Feb 2018 13:10:14 GMT
+      - Tue, 24 Jul 2018 12:40:57 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -33,7 +33,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: ASCII-8BIT
-      string: '{"status":"success","message":"Event processed","dedup_key":"4a820d9dff4f44cf996789f0b1d3e1df"}'
+      string: '{"status":"success","message":"Event processed","dedup_key":"f7603b226f1d4fc69b7ff77fd1fc351a"}'
     http_version: 
-  recorded_at: Thu, 22 Feb 2018 13:10:14 GMT
+  recorded_at: Tue, 24 Jul 2018 12:40:58 GMT
 recorded_with: VCR 3.0.3

--- a/spec/nine_one_one/pager_duty_service_spec.rb
+++ b/spec/nine_one_one/pager_duty_service_spec.rb
@@ -13,7 +13,7 @@ describe NineOneOne::PagerDutyService do
       use_vcr_cassette 'pager_duty_trigger_event_success', match_requests_on: [:body]
 
       it 'calls pager duty service with proper json' do
-        pager_service.trigger_event('Incident description', 'source info', details_hash, severity)
+        pager_service.trigger_event('Incident description', 'source info', details_hash: details_hash, severity: severity)
       end
     end
 
@@ -21,7 +21,7 @@ describe NineOneOne::PagerDutyService do
       use_vcr_cassette 'pager_duty_trigger_event_failure', match_requests_on: [:body]
 
       it 'raises an error' do
-        expect { pager_service.trigger_event('Incident description', nil, {}, severity) }
+        expect { pager_service.trigger_event('Incident description', nil, details_hash: {}, severity: severity) }
           .to raise_error(NineOneOne::IncidentReportingError)
       end
     end

--- a/spec/nine_one_one/pager_duty_service_spec.rb
+++ b/spec/nine_one_one/pager_duty_service_spec.rb
@@ -13,7 +13,7 @@ describe NineOneOne::PagerDutyService do
       use_vcr_cassette 'pager_duty_trigger_event_success', match_requests_on: [:body]
 
       it 'calls pager duty service with proper json' do
-        pager_service.trigger_event('Incident description', 'source info', details_hash: details_hash, severity: severity)
+        pager_service.trigger_event('Incident description', source: 'source info', details_hash: details_hash, severity: severity)
       end
     end
 
@@ -21,7 +21,7 @@ describe NineOneOne::PagerDutyService do
       use_vcr_cassette 'pager_duty_trigger_event_failure', match_requests_on: [:body]
 
       it 'raises an error' do
-        expect { pager_service.trigger_event('Incident description', nil, details_hash: {}, severity: severity) }
+        expect { pager_service.trigger_event('Incident description', source: nil, details_hash: {}, severity: severity) }
           .to raise_error(NineOneOne::IncidentReportingError)
       end
     end

--- a/spec/nine_one_one_spec.rb
+++ b/spec/nine_one_one_spec.rb
@@ -170,10 +170,10 @@ describe NineOneOne do
 
     it 'delegates sending to notifier' do
       allow(NineOneOne).to receive(:use).and_return(notifier)
-      NineOneOne.emergency(message, source, details_hash: details_hash, severity: severity,
-                                            dedup_key: dedup_key)
-      expect(notifier).to have_received(:emergency).with(message, source, details_hash: details_hash,
-                                                                          severity: severity, dedup_key: dedup_key)
+      NineOneOne.emergency(message, source: source, details_hash: details_hash, severity: severity,
+                                    dedup_key: dedup_key)
+      expect(notifier).to have_received(:emergency).with(message, source: source, details_hash: details_hash,
+                                                                  severity: severity, dedup_key: dedup_key)
     end
   end
 

--- a/spec/nine_one_one_spec.rb
+++ b/spec/nine_one_one_spec.rb
@@ -166,11 +166,14 @@ describe NineOneOne do
     let(:message) { 'danger' }
     let(:details_hash) { { why: 'I dont know' } }
     let(:severity) { NineOneOne::PagerDutyService::HIGH_URGENCY_ERROR }
+    let(:dedup_key) { 'dedup_key' }
 
     it 'delegates sending to notifier' do
       allow(NineOneOne).to receive(:use).and_return(notifier)
-      NineOneOne.emergency(message, source, details_hash)
-      expect(notifier).to have_received(:emergency).with(message, source, details_hash, severity)
+      NineOneOne.emergency(message, source, details_hash: details_hash, severity: severity,
+                                            dedup_key: dedup_key)
+      expect(notifier).to have_received(:emergency).with(message, source, details_hash: details_hash,
+                                                                          severity: severity, dedup_key: dedup_key)
     end
   end
 


### PR DESCRIPTION
- Add dedup_key to the event's request body
- Change the interface of `emergency` and `trigger_event` methods to have positional arguments for required ones, and named arguments for optional